### PR TITLE
fix before exclusive conditoin

### DIFF
--- a/src/Traits/BuilderTrait.php
+++ b/src/Traits/BuilderTrait.php
@@ -30,15 +30,15 @@ trait BuilderTrait
 
         if ($direction->value === 'after') {
             $end->$addToDateMethod($duration);
-            $date = $range->value === 'exclusive' ? $date->$addToDateMethod(1) : $date;
-            $end = $range->value === 'exclusive' ? $end->$subFromDateMethod(1) : $end;
+            $date = $range->value === 'exclusive' ? $date->$addToDateMethod(1)->startOfDay() : $date->startOfDay();
+            $end = $range->value === 'exclusive' ? $end->$subFromDateMethod(1)->endOfDay() : $end->endOfDay();
             return $this->whereBetween($this->getClassVars(), [$date, $end]);
 
         }
         if ($direction->value === 'before') {
             $start->$subFromDateMethod($duration);
-            $date = $range->value === 'exclusive' ? $date->$subFromDateMethod(1) : $date;
-            $start = $range->value === 'exclusive' ? $start->$subFromDateMethod(1) : $start;
+            $date = $range->value === 'exclusive' ? $date->$subFromDateMethod(1)->endOfDay() : $date->endOfDay();
+            $start = $range->value === 'exclusive' ? $start->$addToDateMethod(1)->startOfDay() : $start->startOfDay();
 
             return $this->whereBetween($this->getClassVars(), [$start, $date]);
         }


### PR DESCRIPTION
$date = Carbon::parse('2024-01-02’);

//after, inclusive ( 2 )

endDate = '2024-01-04’; // +2

between( date, endDate) // 2024-01-02 -> 2024-01-04

//after, exclusive ( 2 )

endDate = '2024-01-04’; // +2

date = 2024-01-03; // +1
endDate = '2024-01-03; // -1

between( date, endDate) // 2024-01-03 -> 2024-01-03
 
//before, inclusive (2)

startDate = 2023-12-31 // -2

between( startDate, date) // 2023-12-31 -> 2024-01-02

//before, exclusive ( 2 )

startDate = 2023-12-31 // -2

date = 2024-01-01 // -1
startDate = 2023-12-30 // -1 ( this might be an issue to fix )

between( startDate, date) // 2023-12-30 -> 2024-01-01
